### PR TITLE
Rename authid and authrole fields of publisher in Event details

### DIFF
--- a/src/Message/EventMessage.php
+++ b/src/Message/EventMessage.php
@@ -141,20 +141,20 @@ class EventMessage extends Message
      */
     public function disclosePublisher(Session $session)
     {
-
         $details             = $this->getDetails();
         $details->publisher  = $session->getSessionId();
         $details->topic      = $this->topic;
         $authenticationDetails = $session->getAuthenticationDetails();
-        $details->authid     = $authenticationDetails->getAuthId();
-        $details->authrole   = $authenticationDetails->getAuthRole();
-        $details->authroles  = $authenticationDetails->getAuthRoles();
-        $details->authmethod = $authenticationDetails->getAuthMethod();
+        $details->authid             = $authenticationDetails->getAuthId();
+        $details->authrole           = $authenticationDetails->getAuthRole();
+        $details->publisher_authid   = $details->authid;
+        $details->publisher_authrole = $details->authrole;
+        $details->authroles          = $authenticationDetails->getAuthRoles();
+        $details->authmethod         = $authenticationDetails->getAuthMethod();
 
         if ($authenticationDetails->getAuthExtra() !== null) {
             $details->_thruway_authextra = $authenticationDetails->getAuthExtra();
         }
-
     }
 
     /**


### PR DESCRIPTION
**Autobahn|JS** and **Autobahn|Python** uses `publisher_` prefix for `authid` and `authrole` fields in details of the Event:
https://autobahn.readthedocs.io/en/latest/reference/autobahn.wamp.html#autobahn.wamp.types.EventDetails
https://github.com/crossbario/autobahn-js/blob/c7e81a38551c15ca98b13a648e6cf13eae5af4db/lib/session.js#L85
https://github.com/crossbario/autobahn-js/blob/c7e81a38551c15ca98b13a648e6cf13eae5af4db/lib/session.js#L516